### PR TITLE
fix: Can't scroll page after clicking top icon

### DIFF
--- a/src/components/scrollTopButton.js
+++ b/src/components/scrollTopButton.js
@@ -2,12 +2,11 @@ import { Button } from 'antd';
 import { VerticalAlignTopOutlined } from '@ant-design/icons';
 function scrollToTop(timestamp) {
   let scrollTop = document.documentElement.scrollTop || document.body.scrollTop;
-  if (scrollTop > 5) {
-    window.scrollTo(0, scrollTop - scrollTop / 8);
-    window.requestAnimationFrame(scrollToTop);
-  } else {
-    window.scrollTo(0, 0);
-  }
+  window.scrollTo({
+    top: 0,
+    left: 0,
+    behavior: 'smooth',
+  });
 }
 const ScrollTopButton = (props) => {
   return (


### PR DESCRIPTION
## Brief Information
Related issues:
- resolve #58 

## Details
- 代码片段```scrollTo:(0,scrolltop-scrolltop/8)```应当是给用户滚动置顶的感觉，采用```behavior：‘smooth’```代替
- scrolltop属性非负，因此删除了逻辑判断
- 以下视频为修改后的演示：


https://user-images.githubusercontent.com/50283262/220334870-be448f95-25e6-4b7d-a8a3-ede6d08acde3.mp4

