### PR TITLE
Added condition to remove the console in other environment, except development env 

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+NODE_ENV= 'development'

--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,10 @@ const getLastMonth = (lastUpdateTime) => {
 };
 
 const App = () => {
+  const NODE_ENV= process.env.NODE_ENV;
+  if(NODE_ENV!=='development'){
+    console.log = function () {};
+  } 
   const [lastUpdateTime, setLastUpdateTime] = useState(null);
   const { t } = useTranslation();
 


### PR DESCRIPTION
fix #64

Added condition to remove the console in other environment, except development environment. 

Change NODE_ENV value to "staging"/"SIT"/"production" to remove the unnecessary consoles.