### PR TITLE
fix: some metrics cant be displayed normally

### DIFF
--- a/src/components/table.js
+++ b/src/components/table.js
@@ -292,15 +292,17 @@ const solveDate = (year, month) => {
 function dashboard(text, index, t_month) {
   if (index < 300) {
     let [org_name, repo_name] = text.split('/');
+    const t_month_copy = t_month + ' ' + '00:00:00';
     let params = {
       org_name,
       repo_name,
+      t_month_copy,
       t_month,
     };
     return (
       <a
         href={
-          'https://dataease.x-lab.info/link/dqMbZrBk?attachParams=' +
+          'https://dataease.nzcer.cn/link/dqMbZrBk?attachParams=' +
           btoa(JSON.stringify(params))
         }
         target="_blank"

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -302,7 +302,7 @@ function dashboard(text, index, t_month) {
     return (
       <a
         href={
-          'https://dataease.nzcer.cn/link/dqMbZrBk?attachParams=' +
+          'https://dataease.x-lab.info/link/dqMbZrBk?attachParams=' +
           btoa(JSON.stringify(params))
         }
         target="_blank"


### PR DESCRIPTION
## Brief Information

This pull request is in the type of ([more info](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#type) about types):

- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [x] fix
- [ ] perf
- [ ] refactor
- [ ] test

Related issues ([all available keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):

- resolve #104 

## Details
<!-- What did you do in this PR?  -->
- In the external link that jumps to DataEase, the configuration of the t_month parameter is modified.
- Due to possible updates to DataEase, the modified `yyyy-mm-dd hh:mm:ss` cannot be displayed normally on the time panel in the upper left corner.

 ![image](https://github.com/X-lab2017/open-leaderboard/assets/50283262/860afc12-d063-4a7b-b09d-4a60b56845f6)
- So I add a new parameter to control left-top corner time display.

 ![image](https://github.com/X-lab2017/open-leaderboard/assets/50283262/3fde6ade-6d0b-499b-aded-72a7aa472041)



## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/X-lab2017/open-leaderboard/blob/main/README.md) doc

## Others
<!-- Other information you want to share.  -->
<!-- If none to share, leave an "N.A."  -->
